### PR TITLE
Snorkel Save Linear LR Schedule Model

### DIFF
--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -85,6 +85,18 @@ class _CliqueData(NamedTuple):
     end_index: int
     max_cliques: Set[int]
 
+    
+class LinearDecayFunc:
+    def __init__(self, total_steps, warmup_steps) -> None:
+        self.total_steps = total_steps
+        self.warmup_steps = warmup_steps
+
+    def __call__(self, x) -> float:
+        lr = (self.total_steps - self.warmup_steps - x) / (
+                        self.total_steps - self.warmup_steps
+            )
+
+        return lr
 
 class LabelModel(nn.Module, BaseLabeler):
     r"""A model for learning the LF accuracies and combining their output labels.
@@ -767,9 +779,7 @@ class LabelModel(nn.Module, BaseLabeler):
             lr_scheduler = None
         elif lr_scheduler_name == "linear":
             total_steps = self.train_config.n_epochs
-            linear_decay_func = lambda x: (total_steps - self.warmup_steps - x) / (
-                total_steps - self.warmup_steps
-            )
+            linear_decay_func = LinearDecayFunc(total_steps, self.warmup_steps)
             lr_scheduler = optim.lr_scheduler.LambdaLR(  # type: ignore
                 self.optimizer, linear_decay_func
             )


### PR DESCRIPTION
## Description of proposed changes
In Pytorch, we can define a custom LamdaLR function by passing a lambda function. However, [Python3](https://stackoverflow.com/questions/25348532/can-python-pickle-lambda-functions) doesn't handle saving lambda's easily. One solution is to change `pickle` to `dill`, but may break other features. This breaks saving our model in Snorkel as the original implementation creates a lambda for the LR schedule. 

One solution is to create a callable class/object that replaces the lambda (like [here](https://stackoverflow.com/questions/52758051/how-to-save-lambdalr-scheduler-in-pytorch-with-lambda-function)). 

## Test plan
I tested this by running on our existing LabelModel and get the same metric results after training and am able to save the model. 

## Checklist

Need help on these? Just ask!

* [ ] I have read the **CONTRIBUTING** document.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] I have run `tox -e complex` and/or `tox -e spark` if appropriate.
* [ ] All new and existing tests passed.
